### PR TITLE
Fixed a bug with mustache and single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,21 @@ You will need to restart Node-RED for it to pick-up [**Postgrestor**](https://gi
 <img src="http://i.imgur.com/WTpmbT5.png" width="600">
 <img src="http://i.imgur.com/jR0Z08P.png" width="600">
 </p>
+
+
+## Notes for docker
+
+On some docker installations, the user/password msut be configured via environment variables as shown below.
+
+```
+##############################
+  nodered:
+    image: snuids/nodered:v0.20.8-v10
+    container_name: nodered    
+    environment:
+      - TZ=Europe/Paris
+      - PGHOST=mypostgres
+      - PGDATABASE=mydatabase
+      - PGPASSWORD=mypassword
+      - PGUSER=muuser
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgrestor",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "scripts": {
     "test": "eslint postgrestor.js"
   },

--- a/postgrestor.js
+++ b/postgrestor.js
@@ -69,8 +69,10 @@ module.exports = function(RED) {
             node.error(error);
             });
           try {
+            var renderedtemplate=mustache.render(config.query, template).replace(/&#39;/g,"'");
+            
             msg.payload = yield client.query(
-              mustache.render(config.query, template)
+              renderedtemplate
             );
             node.send(msg);
             client.release();


### PR DESCRIPTION
Mustache escapes single quotes with &#39; which is not recognized by postgres. The fix simply replaces &#39; by a single quote before forwarding the request to the postgres client.

Without that, it is impossible to use templating in order to generate insert statements. 